### PR TITLE
change []const u32 to []const u8

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -87,10 +87,10 @@ pub const ShaderModule = extern struct {
     spec_constants: ?[*]SpecializationConstant,
     _internal: ?*anyopaque,
 
-    pub fn init(spv: []const u32) Error!@This() {
+    pub fn init(spv: []const u8) Error!@This() {
         var result: @This() = undefined;
         try spvrErr(spvReflectGetShaderModule(
-            spv.len * @sizeOf(u32),
+            spv.len * @sizeOf(u8),
             spv.ptr,
             @ptrCast(&result),
         ));


### PR DESCRIPTION
In Zig, []const u8 is more commonly used. And converting from []const u8 to []const u32 is not safe.